### PR TITLE
Fix event detection

### DIFF
--- a/source/event_gpio.c
+++ b/source/event_gpio.c
@@ -55,7 +55,7 @@ int epfd_blocking = -1;
 int gpio_export(unsigned int gpio)
 {
     int fd, len;
-    char str_gpio[3];
+    char str_gpio[4];
 
     if ((fd = open("/sys/class/gpio/export", O_WRONLY)) < 0)
        return -1;
@@ -70,7 +70,7 @@ int gpio_export(unsigned int gpio)
 int gpio_unexport(unsigned int gpio)
 {
     int fd, len;
-    char str_gpio[3];
+    char str_gpio[4];
 
     if ((fd = open("/sys/class/gpio/unexport", O_WRONLY)) < 0)
         return -1;
@@ -87,7 +87,7 @@ int gpio_set_direction(unsigned int gpio, unsigned int in_flag)
     int retry;
     struct timespec delay;
     int fd;
-    char filename[33];
+    char filename[34];
 
     snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/direction", gpio);
 
@@ -114,7 +114,7 @@ int gpio_set_direction(unsigned int gpio, unsigned int in_flag)
 int gpio_set_edge(unsigned int gpio, unsigned int edge)
 {
     int fd;
-    char filename[28];
+    char filename[29];
 
     snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/edge", gpio);
 
@@ -129,7 +129,7 @@ int gpio_set_edge(unsigned int gpio, unsigned int edge)
 int open_value_file(unsigned int gpio)
 {
     int fd;
-    char filename[29];
+    char filename[30];
 
     // create file descriptor of value file
     snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);


### PR DESCRIPTION
GPIO numbers can have up to 3 digits now (on nanopi),
hence increasing the length of the buffers by one.